### PR TITLE
Add request validators

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -891,7 +891,7 @@ func (s *Server) exchangeAuthCode(w http.ResponseWriter, authCode storage.AuthCo
 	if !s.isAuthRequestIDValid(authCode.ID) {
 		s.logger.Errorf("Invalid auth code")
 		s.tokenErrHelper(w, errInvalidRequest, "Invalid auth code passed", http.StatusBadRequest)
-		return nil, fmt.Error("Invalid auth code")
+		return nil, fmt.Errorf("invalid auth code")
 	}
 
 	accessToken, err := s.newAccessToken(client.ID, authCode.Claims, authCode.Scopes, authCode.Nonce, authCode.ConnectorID)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -300,7 +300,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 
 	authReqID := r.FormValue("req")
 
-	if !s.isAuthRequestIDValid(authReqID) {
+	if !s.validateBase32EncodedId(authReqID) {
 		s.logger.Errorf("Invalid auth request id")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid Auth Request ID")
 		return
@@ -435,7 +435,7 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !s.isAuthRequestIDValid(authID) {
+	if !s.validateBase32EncodedId(authID) {
 		s.logger.Errorf("Invalid auth request id")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid Auth Request ID")
 		return
@@ -579,7 +579,7 @@ func (s *Server) finalizeLogin(identity connector.Identity, authReq storage.Auth
 
 func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	secureID := r.FormValue("req")
-	if !s.isAuthRequestIDValid(secureID) {
+	if !s.validateBase32EncodedId(secureID) {
 		s.logger.Errorf("Invalid auth request")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid requestID passed")
 		return
@@ -627,7 +627,7 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 		return
 	}
 
-	if !s.isAuthRequestIDValid(authReq.ID) {
+	if !s.validateBase32EncodedId(authReq.ID) {
 		s.logger.Errorf("Invalid auth request")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid requestID passed")
 		return
@@ -831,7 +831,7 @@ func (s *Server) handleAuthCode(w http.ResponseWriter, r *http.Request, client s
 	code := r.PostFormValue("code")
 	redirectURI := r.PostFormValue("redirect_uri")
 
-	if !s.isAuthRequestIDValid(code) {
+	if !s.validateBase32EncodedId(code) {
 		s.logger.Errorf("Invalid auth code")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid auth code passed")
 		return
@@ -888,7 +888,7 @@ func (s *Server) handleAuthCode(w http.ResponseWriter, r *http.Request, client s
 }
 
 func (s *Server) exchangeAuthCode(w http.ResponseWriter, authCode storage.AuthCode, client storage.Client) (*accessTokenReponse, error) {
-	if !s.isAuthRequestIDValid(authCode.ID) {
+	if !s.validateBase32EncodedId(authCode.ID) {
 		s.logger.Errorf("Invalid auth code")
 		s.tokenErrHelper(w, errInvalidRequest, "Invalid auth code passed", http.StatusBadRequest)
 		return nil, fmt.Errorf("invalid auth code")
@@ -1530,8 +1530,9 @@ func (s *Server) tokenErrHelper(w http.ResponseWriter, typ string, description s
 }
 
 // Validate Auth Request ID
-func (s *Server) isAuthRequestIDValid(id string) bool {
+func (s *Server) validateBase32EncodedId(id string) bool {
 	// Request ID is a 32 bit encoded string
+	// Check https://github.com/chef/dex-1/blob/master/storage/storage.go#L41 for details
 	re := regexp.MustCompile(`(?i)^[a-z0-7]+$`)
 	return re.Match([]byte(id))
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1526,7 +1526,7 @@ func (s *Server) tokenErrHelper(w http.ResponseWriter, typ string, description s
 // Validate Auth Request ID
 func (s *Server) isAuthRequestIDValid(id string) bool {
 	// Request ID is a 32 bit encoded string
-	re := regexp.MustCompile(`(?i)^[a-z0-7]$`)
+	re := regexp.MustCompile(`(?i)^[a-z0-7]+$`)
 	return re.Match([]byte(id))
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -568,7 +568,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	authReq, err := s.storage.GetAuthRequest(r.FormValue("req"))
 	if err != nil {
 		s.logger.Errorf("Failed to get auth request: %v", err)
-		s.renderError(r, w, http.StatusInternalServerError, "Database error.")
+		s.renderError(r, w, http.StatusInternalServerError, "Authkey not found")
 		return
 	}
 	if !authReq.LoggedIn {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -303,6 +303,7 @@ func (s *Server) handleConnectorLogin(w http.ResponseWriter, r *http.Request) {
 	if !s.isAuthRequestIDValid(authReqID) {
 		s.logger.Errorf("Invalid auth request id")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid Auth Request ID")
+		return
 	}
 
 	authReq, err := s.storage.GetAuthRequest(authReqID)
@@ -437,6 +438,7 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
 	if !s.isAuthRequestIDValid(authID) {
 		s.logger.Errorf("Invalid auth request id")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid Auth Request ID")
+		return
 	}
 
 	authReq, err := s.storage.GetAuthRequest(authID)
@@ -580,6 +582,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	if !s.isAuthRequestIDValid(secureID) {
 		s.logger.Errorf("Invalid auth request")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid requestID passed")
+		return
 	}
 
 	authReq, err := s.storage.GetAuthRequest(secureID)
@@ -627,6 +630,7 @@ func (s *Server) sendCodeResponse(w http.ResponseWriter, r *http.Request, authRe
 	if !s.isAuthRequestIDValid(authReq.ID) {
 		s.logger.Errorf("Invalid auth request")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid requestID passed")
+		return
 	}
 
 	if err := s.storage.DeleteAuthRequest(authReq.ID); err != nil {
@@ -830,6 +834,7 @@ func (s *Server) handleAuthCode(w http.ResponseWriter, r *http.Request, client s
 	if !s.isAuthRequestIDValid(code) {
 		s.logger.Errorf("Invalid auth code")
 		s.renderError(r, w, http.StatusBadRequest, "Invalid auth code passed")
+		return
 	}
 
 	authCode, err := s.storage.GetAuthCode(code)
@@ -886,6 +891,7 @@ func (s *Server) exchangeAuthCode(w http.ResponseWriter, authCode storage.AuthCo
 	if !s.isAuthRequestIDValid(authCode.ID) {
 		s.logger.Errorf("Invalid auth code")
 		s.tokenErrHelper(w, errInvalidRequest, "Invalid auth code passed", http.StatusBadRequest)
+		return nil, fmt.Error("Invalid auth code")
 	}
 
 	accessToken, err := s.newAccessToken(client.ID, authCode.Claims, authCode.Scopes, authCode.Nonce, authCode.ConnectorID)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -204,3 +204,30 @@ func TestConnectorLoginDoesNotAllowToChangeConnectorForAuthRequest(t *testing.T)
 		t.Error("attempt to overwrite connector on auth request should fail")
 	}
 }
+
+func TestHandleInvalidApprovalCode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	httpServer, server := newTestServer(ctx, t, func(c *Config) {
+		c.Storage = &emptyStorage{c.Storage}
+	})
+	defer httpServer.Close()
+
+	tests := []struct {
+		TargetURI    string
+		ExpectedCode int
+	}{
+		{"/approval?req=etsk5jfjfq2ao7s2pfthls72m%20HTTP/1.1", http.StatusBadRequest},
+		{"/approval?req=ProbePhishing", http.StatusBadRequest},
+	}
+
+	rr := httptest.NewRecorder()
+
+	for i, r := range tests {
+		server.ServeHTTP(rr, httptest.NewRequest("GET", r.TargetURI, nil))
+		if rr.Code != r.ExpectedCode {
+			t.Fatalf("test %d expected %d, got %d", i, r.ExpectedCode, rr.Code)
+		}
+	}
+}


### PR DESCRIPTION
#### Overview

#### What this PR does / why we need it

These changes are required to validate authentication key before we hit the DB.
The authentication key is generated using base32 encoding so we should validate the key.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

The invalid keys generate an error `Database Error.`
There will be a change:
- In case of valid key but not found in DB, the error will show `Auth Request ID not found` / `
 - In case of invalid key, the error will show `Invalid auth code passed`